### PR TITLE
Update repo README links and site title

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The PFF database will be an ideal teaching tool for students interested in the h
 
 Petitions for Freedom: Habeas Corpus in the Borderlands of Freedom & Slavery is a project directed by Katrina Jagodinsky, and published jointly by the Center for Digital Research in the Humanities and the Department of History at the University of Nebraska, Lincoln.
 
-**Project Site:** Site is not live.
+**Project Site:** [https://petitioningforfreedom.unl.edu/](https://petitioningforfreedom.unl.edu/)
 
 **Rails Repo:** [https://github.com/CDRH/habeascorpus](https://github.com/CDRH/habeascorpus)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Data Repository for Petitioning for Freedom: Habeas Corpus in the Borderlands of Freedom & Slavery  
+# Data Repository for Petitioning for Freedom: Habeas Corpus in the American West, 1812-1924
 
 ## About This Data Repository
 
-**How to Use This Repository:** This repository is intended for use with the [CDRH API](https://github.com/CDRH/api) and the [Habeas Corpus Ruby on Rails application](https://github.com/CDRH/habeascorpus).
+**How to Use This Repository:** This repository is intended for use with the [CDRH API](https://github.com/CDRH/api) and the [Petitioning for Freedom Ruby on Rails application](https://github.com/CDRH/habeascorpus).
 
-Issues go on the [Habeas Corpus Rails App Repo](https://github.com/CDRH/habeascorpus)
+Issues go on the [Petitioning for Freedom Rails app repository](https://github.com/CDRH/habeascorpus).
 
 # Downloading the data
 
@@ -19,7 +19,7 @@ Run `post -f tei` first to post the case documents. This will update the json fi
 Then run `post -f csv` to post the csv files for cases. Information about associations will be included in the case records.
 If you simply run `post` without following this order, the associations for cases may be missing or not up to date.
 
-**Data Repo:** [https://github.com/CDRH/data_habeascorpus](https://github.com/CDRH/data_habeascorpus)
+**Data Repo:** [https://github.com/CDRH/data_petitioning-for-freedom](https://github.com/CDRH/data_petitioning-for-freedom)
 
 **Source Files:** TEI XML, CSV
 
@@ -27,19 +27,19 @@ If you simply run `post` without following this order, the associations for case
 
 **Encoding Schema:** [Text Encoding Initiative (TEI) Guidelines](https://tei-c.org/release/doc/tei-p5-doc/en/html/index.html)
 
-## About Petitioning for Freedom: Habeas Corpus in the Borderlands of Freedom & Slavery  
+## About Petitioning for Freedom: Habeas Corpus in the American West, 1812-1924 
 
 The Petitioning for Freedom (PFF) project offers humanities and social science scholars access to a database of thousands of unpublished and mostly unindexed habeas petitions from multiple jurisdictions throughout the American West filed between 1812 and 1924. As a dataset, the collection offers a detailed portrait of ordinary peoples' use of the law in the long nineteenth century that allows scholars to consider individual petitions as a collective challenge to inequality and injustice. This database highlights the efforts of marginalized people to right the wrongs that made them subject to others' authority and this study links their petitions to legal reform that has previously been understood as the domain of middle-class reformers, jurists, and politicians. 
 
 The PFF database will be an ideal teaching tool for students interested in the histories of race, gender, family, and the law and is applicable in a broad range of classes in the humanities and social sciences. Users will be able to search the database through a considerable number of categories, making the dataset responsive to a diverse set of research questions. 
 
-Petitions for Freedom: Habeas Corpus in the Borderlands of Freedom & Slavery is a project directed by Katrina Jagodinsky, and published jointly by the Center for Digital Research in the Humanities and the Department of History at the University of Nebraska, Lincoln.
+Petitions for Freedom: Habeas Corpus in the American West, 1812-1924 is a project directed by Katrina Jagodinsky, and published jointly by the Center for Digital Research in the Humanities and the Department of History at the University of Nebraska–Lincoln.
 
 **Project Site:** [https://petitioningforfreedom.unl.edu/](https://petitioningforfreedom.unl.edu/)
 
 **Rails Repo:** [https://github.com/CDRH/habeascorpus](https://github.com/CDRH/habeascorpus)
 
-**Credits:** [https://github.com/CDRH/data_habeascorpus/graphs/contributors](https://github.com/CDRH/data_habeascorpus/graphs/contributors)
+**Credits:** [https://github.com/CDRH/data_petitioning-for-freedom/graphs/contributors](https://github.com/CDRH/data_petitioning-for-freedom/graphs/contributors)
 
 **Work to Be Done:** [https://github.com/CDRH/habeascorpus/issues](https://github.com/CDRH/habeascorpus/issues)
 


### PR DESCRIPTION
README was written back when the project name was still "Habeas Corpus" and then partially updated when it was "Petitioning for Freedom: Habeas Corpus in the Borderlands of Freedom & Slavery." These two commits bring it up to speed with
1. The new project/site title, "Petitioning for Freedom: Habeas Corpus in the American West, 1812-1924", and
2. The new name/URL for the data repo, which is now `data_petitioning-for-freedom` instead of `data_habeascorpus`
 
The name/URL for the Rails repo has not yet changed. We can push another update to the README when it does.